### PR TITLE
관리자 권한 영화 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/review/controller/UserController.java
+++ b/src/main/java/com/review/controller/UserController.java
@@ -24,9 +24,13 @@ public class UserController {
     @PostMapping("/register")
     public ResponseEntity<String> registerUser(@Valid @RequestBody User user) {
         if (userService.registerUser(user)) {
-            return ResponseEntity.ok("회원가입이 완료되었습니다. 좋은 리뷰 공간을 만들어주세요.");
+            if ("ADMIN".equals(user.getRole())) {
+                return ResponseEntity.ok("관리자 권한으로 회원가입이 완료되었습니다. 좋은 리뷰 공간을 위해 힘써주세요.");
+            } else {
+                return ResponseEntity.ok("회원가입이 완료되었습니다. 좋은 리뷰 공간을 만들어주세요.");
+            }
         } else {
-            return ResponseEntity.badRequest().body("Registration failed. Username might be taken or invalid.");
+            return ResponseEntity.badRequest().body("회원가입을 실패했습니다. 입력하신 정보를 다시 한 번 확인해주세요.");
         }
     }
 

--- a/src/main/java/com/review/entity/Movie.java
+++ b/src/main/java/com/review/entity/Movie.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -34,7 +35,7 @@ public class Movie {
     @ElementCollection
     @CollectionTable(name = "movie_cast", joinColumns = @JoinColumn(name = "movie_id"))
     @Column(name = "cast_member")
-    private List<String> cast;  // 출연진 (최대 3명)
+    private List<String> cast = new ArrayList<>();  // 출연진 (최대 3명), ArrayList로 초기화
 
     @Column(nullable = false, length = 1000)
     private String plot;  // 줄거리
@@ -42,6 +43,4 @@ public class Movie {
     @Column(nullable = false)
     private String createdBy;  // 최초 등록자
 
-    // Getters and Setters
-    // 기본 생성자, 필드 기반 생성자 등
 }

--- a/src/main/java/com/review/entity/User.java
+++ b/src/main/java/com/review/entity/User.java
@@ -38,4 +38,7 @@ public class User {
     @NotBlank(message = "Password is mandatory")
     private String password;  // 사용자 비밀번호
 
+    @Column(nullable = false)
+    private String role = "USER"; // 별도의 입력이 없을 경우 기본값 USER
+
 }

--- a/src/main/java/com/review/service/MovieService.java
+++ b/src/main/java/com/review/service/MovieService.java
@@ -23,10 +23,10 @@ public class MovieService {
     }
 
 
-    // 영화 ID로 영화 찾기 (추가된 부분)
-    public Optional<Movie> findById(Long id) {
-        return movieRepository.findById(id);
-    }
+//    // 영화 ID로 영화 찾기 (추가된 부분)
+//    public Optional<Movie> findById(Long id) {
+//        return movieRepository.findById(id);
+//    }
 
     // 영화 저장
     public Movie saveMovie(Movie movie) {


### PR DESCRIPTION
📋 개요 (Summary)

- 관리자 로그인 기능 구현
- 관리자 권한 영화 정보 수정 기능 구현


💡 변경 사항 (What & Why)

- 관리자 권한으로만 영화정보 수정이 가능하도록 User Entity 에 "role" 을 추가하여 별도의 "ADMIN" 입력 없이 회원가입을 진행할 경우에는 기본적으로 User 권한을 "ADMIN"을 입력시 관리자 권한으로 회원가입이 가능하도록 수정했습니다.



🔍 관련 이슈 (Related Issue)

- 관리자 권한 리뷰 수정 기능을 첫 테스트할 때 ImmutableCollections와 관련된 예외가 발생했고 Movie 엔티티에서 cast 필드를 불변 컬렉션으로 설정하거나, 수정할 수 없는 방식으로 처리한 경우에 나올 수 있는 오류라고 해서 cast 필드에 값을 List.of(...) 가 아닌 new ArrayList<>(...) 로 수정/오류 해결했습니다.


✅ 체크리스트 (Checklist)

- 코드가 정상적으로 작동하는지 확인했습니다.


🚀 테스트 결과 (Test Result)

- postman을 통해 관리자용 회원가입/로그인 기능이 정상적으로 가능한 것을 확인
- 관리자가 수정한 영화 정보가 리부와 함꼐 정상적으로 반환되는 것을 확인
- 로그인하지않은 이용자가 영화 (제목,출시년도)검색 / 조회 가능한 것을 확인 


💬 기타 사항 (Additional Information) / 질문

- 리부 검열 기능 구현 예정