### PR TITLE
리뷰 검열 기능

### DIFF
--- a/src/main/java/com/review/controller/ForbiddenWordController.java
+++ b/src/main/java/com/review/controller/ForbiddenWordController.java
@@ -1,0 +1,88 @@
+package com.review.controller;
+
+import com.review.entity.ForbiddenWord;
+import com.review.entity.User;
+import com.review.service.ForbiddenWordService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/forbidden-words")
+public class ForbiddenWordController {
+
+    private final ForbiddenWordService forbiddenWordService;
+
+    @Autowired
+    public ForbiddenWordController(ForbiddenWordService forbiddenWordService) {
+        this.forbiddenWordService = forbiddenWordService;
+    }
+
+    //  검열 단어 목록 조회
+    @GetMapping
+    public ResponseEntity<List<String>> getForbiddenWords(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute("user") == null) {
+            return ResponseEntity.status(401).body(null);
+        }
+
+        // 세션에서 User 객체를 가져옵니다.
+        User user = (User) session.getAttribute("user");
+
+        // 관리자 권한 확인
+        if (!"ADMIN".equals(user.getRole())) {
+            return ResponseEntity.status(403).body(null);
+        }
+
+        List<ForbiddenWord> words = forbiddenWordService.getAllForbiddenWords();
+        List<String> wordList = words.stream().map(ForbiddenWord::getWord).toList();
+        return ResponseEntity.ok(wordList);
+    }
+
+
+    // 검열 단어 추가
+    @PostMapping
+    public ResponseEntity<String> addForbiddenWord(@RequestParam String word, HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute("user") == null) {
+            return ResponseEntity.status(401).body("관리자 권한 로그인이 필요합니다.");
+        }
+
+        User user = (User) session.getAttribute("user");
+        // 관리자 확인
+        if(!"ADMIN".equals(user.getRole())) {
+            return ResponseEntity.status(403).body("관리자 권한이 필요합니다.");
+        }
+
+        // 단어 중복 체크
+        if(forbiddenWordService.containsForbiddenWord(word)){
+            return ResponseEntity.badRequest().body("이미 존재하는 단어입니다.");
+        }
+
+        forbiddenWordService.addForbiddenWord(word);
+        return ResponseEntity.ok("검열단어가 추가되었습니다.");
+    }
+
+
+    // 검열 단어 삭제
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteForbiddenWord(@RequestParam String word, HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute("user") == null) {
+            return ResponseEntity.status(401).body("관리자 권한 로그인이 필요합니다.");
+        }
+
+        User user = (User) session.getAttribute("user");
+        // 관리자 확인
+        if(!"ADMIN".equals(user.getRole())) {
+            return ResponseEntity.status(403).body("관리자 권한이 필요합니다.");
+        }
+
+        forbiddenWordService.deleteForbiddenWord(word);
+        return ResponseEntity.ok("검열 단어가 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/review/controller/MovieController.java
+++ b/src/main/java/com/review/controller/MovieController.java
@@ -3,6 +3,7 @@ package com.review.controller;
 import com.review.entity.Movie;
 import com.review.entity.Review;
 import com.review.entity.User;  // User 클래스 import 추가
+import com.review.service.ForbiddenWordService;
 import com.review.service.MovieService;
 import com.review.service.ReviewService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,12 +22,15 @@ public class MovieController {
 
     private final MovieService movieService;
     private final ReviewService reviewService;
+    private final ForbiddenWordService forbiddenWordService;  // ForbiddenWordService 추가
 
     @Autowired
-    public MovieController(MovieService movieService, ReviewService reviewService) {
+    public MovieController(MovieService movieService, ReviewService reviewService, ForbiddenWordService forbiddenWordService) {  // ForbiddenWordService 주입
         this.movieService = movieService;
         this.reviewService = reviewService;
+        this.forbiddenWordService = forbiddenWordService;  // 주입된 ForbiddenWordService 초기화
     }
+
 
     // 영화 정보 등록 및 리뷰 작성 (최초 등록 시)
     @PostMapping("/review")
@@ -50,6 +54,11 @@ public class MovieController {
 
         // 세션에서 User 객체를 가져옵니다.
         User user = (User) session.getAttribute("user");
+
+        // 리뷰 내용에 검열 단어가 포함되어 있는지 확인
+        if (forbiddenWordService.containsForbiddenWord(reviewContent)) {
+            return ResponseEntity.badRequest().body("부정적인 언어의 사용으로 리뷰 등록이 불가능합니다.");
+        }
 
         // 영화 정보 확인
         Optional<Movie> existingMovie = movieService.findByTitleAndReleaseYear(title, releaseYear);

--- a/src/main/java/com/review/entity/ForbiddenWord.java
+++ b/src/main/java/com/review/entity/ForbiddenWord.java
@@ -1,0 +1,22 @@
+package com.review.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity(name = "forbidden_words")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ForbiddenWord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column(nullable = false,unique = true) // 공백값, 중복값 없도록 설정
+    private String word; // 검열 단어
+}

--- a/src/main/java/com/review/repository/ForbiddenWordRepository.java
+++ b/src/main/java/com/review/repository/ForbiddenWordRepository.java
@@ -1,0 +1,12 @@
+package com.review.repository;
+
+import com.review.entity.ForbiddenWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ForbiddenWordRepository extends JpaRepository<ForbiddenWord, Long> {
+    Optional<ForbiddenWord> findByWord(String word);
+}

--- a/src/main/java/com/review/service/ForbiddenWordService.java
+++ b/src/main/java/com/review/service/ForbiddenWordService.java
@@ -1,0 +1,55 @@
+package com.review.service;
+
+import com.review.entity.ForbiddenWord;
+import com.review.repository.ForbiddenWordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ForbiddenWordService {
+
+    private final ForbiddenWordRepository forbiddenWordRepository;
+
+    @Autowired
+    public ForbiddenWordService(ForbiddenWordRepository forbiddenWordRepository) {
+        this.forbiddenWordRepository = forbiddenWordRepository;
+    }
+
+    // 모든 검열단어 조회
+    public List<ForbiddenWord> getAllForbiddenWords() {
+        return forbiddenWordRepository.findAll();
+    }
+
+    // 검열단어 추가
+    public ForbiddenWord addForbiddenWord(String word) {
+        ForbiddenWord forbiddenWord = new ForbiddenWord();
+        forbiddenWord.setWord(word);
+        return forbiddenWordRepository.save(forbiddenWord);
+    }
+
+    // 검열 단어 삭제
+    public void deleteForbiddenWord(String word) {
+        Optional<ForbiddenWord> forbiddenWord = forbiddenWordRepository.findByWord(word);
+        // 단어가 존재하면 삭제
+        if (forbiddenWord.isPresent()) {
+            forbiddenWordRepository.delete(forbiddenWord.get());
+        }
+    }
+
+    // 리뷰 내용 검열단어 포함했는가 확인
+    public boolean containsForbiddenWord(String content) {
+        List<ForbiddenWord> forbiddenWords = getAllForbiddenWords();
+        for(ForbiddenWord forbiddenWord : forbiddenWords) {
+            if(content.contains(forbiddenWord.getWord())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+
+}


### PR DESCRIPTION
📋 개요 (Summary)

- 리뷰 검열기능 구현
- 관리자 권한 검열 단어 등록/추가/삭제 기능 구현 

 

💡 변경 사항 (What & Why)

- 리뷰 검열을 위한 기능을 구현한 뒤 MovieController에도 리뷰 작성/등록과 동시에 리뷰 검열할 수 있는 로직을 추가했습니다.
- 검열단어 등록과 동시에 int id 값이 부여되는 것이 추가/삭제하는 과정에서 매끄럽지 못하다고 생각하여 직접적인 단어로 추가/삭제할 수 있도록 바꾸었습니다 


🔍 관련 이슈 (Related Issue)

- 없음.


✅ 체크리스트 (Checklist)

- 코드가 정상적으로 작동하는지 확인했습니다. 


🚀 테스트 결과 (Test Result)

- postman을 통해 관리자 권한 검열 단어 등록/추가/삭제 되는 것을 확인


💬 기타 사항 (Additional Information) / 질문

- 영화 검색 기능 구현 예정