### PR TITLE
영화 검색 기능 구현 1차 / 영화 전체 목록 조회

### DIFF
--- a/src/main/java/com/review/controller/MovieController.java
+++ b/src/main/java/com/review/controller/MovieController.java
@@ -9,6 +9,7 @@ import com.review.service.ReviewService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -216,6 +217,17 @@ public class MovieController {
         movieService.saveMovie(existingMovie);
 
         return ResponseEntity.ok("관리자의 권한으로 영화 정보가 수정되었습니다.");
+    }
+
+    // 영화 목록 조회 (카테고리와 제목 종류로 구분)
+    @GetMapping("/list")
+    public ResponseEntity<Page<Movie>> getMovies(
+            @RequestParam String category,  // "장편" 또는 "단편"
+            @RequestParam boolean isKorean, // true면 한글 제목, false면 영어 제목
+            @RequestParam int page) {       // 페이지 번호
+
+        Page<Movie> movies = movieService.getMoviesByCategoryAndTitle(category, isKorean, page);
+        return ResponseEntity.ok(movies);
     }
 
 

--- a/src/main/java/com/review/repository/MovieRepository.java
+++ b/src/main/java/com/review/repository/MovieRepository.java
@@ -1,10 +1,19 @@
 package com.review.repository;
 
 import com.review.entity.Movie;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface MovieRepository extends JpaRepository<Movie, Long> {
     Optional<Movie> findByTitleAndReleaseYear(String title, int releaseYear);
+
+    // 장편/단편 구분 및 제목의 첫 글자가 한글 또는 영어로 시작하는 영화 목록을 페이지 형식으로 가져옴
+    @Query("SELECT m FROM movies m WHERE m.category = :category AND " +
+            "((:isKorean = true AND SUBSTRING(m.title, 1, 1) BETWEEN '가' AND '힣') OR " +
+            " (:isKorean = false AND SUBSTRING(m.title, 1, 1) BETWEEN 'A' AND 'Z'))")
+    Page<Movie> findByCategoryAndTitleMatchingFirstLetter(String category, boolean isKorean, Pageable pageable);
 }

--- a/src/main/java/com/review/service/MovieService.java
+++ b/src/main/java/com/review/service/MovieService.java
@@ -3,6 +3,9 @@ package com.review.service;
 import com.review.entity.Movie;
 import com.review.repository.MovieRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -31,5 +34,22 @@ public class MovieService {
     // 영화 저장
     public Movie saveMovie(Movie movie) {
         return movieRepository.save(movie);
+    }
+
+    // 장편/단편 카테고리와 한글/영어 제목 구분에 따른 영화 목록 조회
+    public Page<Movie> getMoviesByCategoryAndTitle(String category, boolean isKorean, int page) {
+        int pageSize = 20; // 페이지당 최대 영화 개수
+        Sort sort = Sort.by(Sort.Order.asc("title")); // 정렬 기준 (한글/영어 모두 제목 순 정렬)
+
+        PageRequest pageRequest = PageRequest.of(page, pageSize, sort);
+
+        // 한글/영어 구분에 따라 검색
+        if (isKorean) {
+            // 한글 제목의 영화 검색 (제목의 첫 글자가 한글인지 확인)
+            return movieRepository.findByCategoryAndTitleMatchingFirstLetter(category, true, pageRequest);
+        } else {
+            // 영어 제목의 영화 검색 (제목의 첫 글자가 영어인지 확인)
+            return movieRepository.findByCategoryAndTitleMatchingFirstLetter(category, false, pageRequest);
+        }
     }
 }


### PR DESCRIPTION
📋 개요 (Summary)

- 등록된 영화 목록 전체를 ( 카테고리 -> 영화제목 을 통해 ) 조회하는 기능 구현


💡 변경 사항 (What & Why)

- 기존 MovieRepository / MovieService / MovieController 에 각각 장편/단편 카테고리와 한글/영어 제목 구분에 따른 영화 목록 조회 기능 로직 추가 작성


🔍 관련 이슈 (Related Issue)

- 처음 영화 제목을 한글/영어 기준으로 검색하는 로직을 findByCategoryAndTitleStartingWith 로 작성했다가 영화 제목의 첫 글자가 "가" / "A"  아닌 경우에는 노출되지 않는 오류가 있었습니다. 이를 findByCategoryAndTitleContaining 로 바꾸어 특정 범위의 첫 글자가 아닌 한글/영어 범위를 전체로 수정하여 오류를 해결했습니다.
- 영화 제목이 한글과 영문의 혼합일 경우 첫 글자를 기준으로 분류하도록 수정
- 페이지형식으로 한 페이지에 2ㅐ개씩 노출되도록 구혐


✅ 체크리스트 (Checklist)

- 테스트를 통해 잘 작동하는 것을 확인


🚀 테스트 결과 (Test Result)

- postman을 통해 영화 카테고리/제목/페이지번호 으로 해당 조건들의 등록된 전체 영화가 반환되는 것을 확인


💬 기타 사항 (Additional Information) / 질문

- 영화 검색 기능 2차 구현 예정 (미디어 제목,출시년도로 검색)

