### PR TITLE
영화 검색 기능 구현 1차 수정 / 영화 검색 기능 구현 2차 (제목으로 리뷰 검색) 기능 구현

### DIFF
--- a/src/main/java/com/review/repository/MovieRepository.java
+++ b/src/main/java/com/review/repository/MovieRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MovieRepository extends JpaRepository<Movie, Long> {
@@ -16,4 +17,7 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
             "((:isKorean = true AND SUBSTRING(m.title, 1, 1) BETWEEN '가' AND '힣') OR " +
             " (:isKorean = false AND SUBSTRING(m.title, 1, 1) BETWEEN 'A' AND 'Z'))")
     Page<Movie> findByCategoryAndTitleMatchingFirstLetter(String category, boolean isKorean, Pageable pageable);
+
+    List<Movie> findByTitle(String title);
+
 }

--- a/src/main/java/com/review/repository/ReviewRepository.java
+++ b/src/main/java/com/review/repository/ReviewRepository.java
@@ -2,10 +2,13 @@ package com.review.repository;
 
 import com.review.entity.Movie;
 import com.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByMovie(Movie movie);
+    Page<Review> findByMovie(Movie movie, Pageable pageable);
 }

--- a/src/main/java/com/review/service/MovieService.java
+++ b/src/main/java/com/review/service/MovieService.java
@@ -1,23 +1,29 @@
 package com.review.service;
 
 import com.review.entity.Movie;
+import com.review.entity.Review;
 import com.review.repository.MovieRepository;
+import com.review.repository.ReviewRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 public class MovieService {
 
     private final MovieRepository movieRepository;
+    private final ReviewRepository reviewRepository;
 
     @Autowired
-    public MovieService(MovieRepository movieRepository) {
+    public MovieService(MovieRepository movieRepository, ReviewRepository reviewRepository) {
         this.movieRepository = movieRepository;
+        this.reviewRepository = reviewRepository;
     }
 
     // 제목과 출시년도로 영화 찾기
@@ -43,13 +49,14 @@ public class MovieService {
 
         PageRequest pageRequest = PageRequest.of(page, pageSize, sort);
 
-        // 한글/영어 구분에 따라 검색
-        if (isKorean) {
-            // 한글 제목의 영화 검색 (제목의 첫 글자가 한글인지 확인)
-            return movieRepository.findByCategoryAndTitleMatchingFirstLetter(category, true, pageRequest);
-        } else {
-            // 영어 제목의 영화 검색 (제목의 첫 글자가 영어인지 확인)
-            return movieRepository.findByCategoryAndTitleMatchingFirstLetter(category, false, pageRequest);
-        }
+        // isKorean 값을 그대로 repository로 전달
+        return movieRepository.findByCategoryAndTitleMatchingFirstLetter(category, isKorean, pageRequest);
     }
+
+
+    // 영화 제목으로 리뷰 목록을 페이지 단위로 제공
+    public List<Movie> findByTitle(String title) {
+        return movieRepository.findByTitle(title);
+    }
+
 }

--- a/src/main/java/com/review/service/ReviewService.java
+++ b/src/main/java/com/review/service/ReviewService.java
@@ -4,6 +4,8 @@ import com.review.entity.Movie;
 import com.review.entity.Review;
 import com.review.repository.ReviewRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +41,11 @@ public class ReviewService {
     // 리뷰 삭제
     public void deleteReviewById(Long id) {
         reviewRepository.deleteById(id);
+    }
+
+    // 영화에 대한 리뷰를 페이징하여 반환하는 메서드 추가
+    public Page<Review> findByMovie(Movie movie, Pageable pageable) {
+        return reviewRepository.findByMovie(movie, pageable);
     }
 
 }


### PR DESCRIPTION
📋 개요 (Summary)

- 영화 제목으로 리뷰를 검색하는 기능 구현


💡 변경 사항 (What & Why)

- 영화 검색 기능 구현 1차에서 피드백받은 MovieService 속 제목구분으로 영화 목록 조회하는 로직에서 if else 문 수정
- 사용자가 영화 제목만으로 검색한 뒤에 동일한 제목의 영화가 존재할 경우 년도를 추가 입력하도록 로직을 작성했는데 초반에 작성했던 영화 제목+ 출시 연도로 리뷰 목록을 조회하는 기능과 비숫한 것 같아 두 로직을 하나로 합쳤습니다. 그리고 해당 년도에 등록된 영화가 없을 경우 "해당 년도에 출시된 영화가 없습니다." 라는 멘트가 게종되도록 추가했습니다.


🔍 관련 이슈 (Related Issue)

- 영화 검색 기능 구현 1차에서 피드백받은 엔티티 객체를 그대로 반환하지않고 dto로 변환하여 내려주도록 하는 로직을 수정하다가 오류가 잡히지않아 수정 전으로 복구하였습니다. 계속 수정하면서 오류가 해결되지않고 정살적으로 작동하면 수정 후 commit 하겠습니다. 


✅ 체크리스트 (Checklist)

- 테스트를 통해 잘 작동하는 것을 확인


🚀 테스트 결과 (Test Result)

- postman을 통해 '제목->(동일한 제목의 영화가 존재할 경우) 년도 추가입력-> 리뷰 조회' 순서대로 정상 반환하는 것을 확인
- 이용자가 제목+출시년도를 동시에 입력해도 해당 영화의 리뷰가 정상적으로 반환하는 것을 확인


💬 기타 사항 (Additional Information) / 질문

- 엔티티 객체를 그대로 반환하지않고 dto로 변환하여 내려주도록 하는 로직 계속 추가 수정 예정
- 배우 이름으로 영화 리뷰 목록을 조회하는 기능 구현 예정

